### PR TITLE
Annotation, AnnotationTarget, AnnotationBody, Selector Serializers an…

### DIFF
--- a/lfc-api/LookingForConcerts/LookingForConcerts/urls.py
+++ b/lfc-api/LookingForConcerts/LookingForConcerts/urls.py
@@ -94,9 +94,12 @@ urlpatterns = [
     url(r'^concert/(?P<pk>[0-9]+)/rate/$', views.rate_concert), # adds a new rating by the logged in user to the concert specified by its primary key; requires authorization
     url(r'^concert/(?P<pk>[0-9]+)/average_ratings/$', views.get_average_ratings), # returns the average ratings for the concert specified by its primary key
     # ANNOTATION
-    url(r"^concert/(?P<concert_id>\d+)/annotations$", views.list_annotations),
-    url(r"^concert/(?P<concert_id>\d+)/annotations/(?P<pk>\d+)$", views.annotation_detail),
-
+    url(r"^/concerts_annotations/$", views.list_annotations), #returns all annotations about a concert
+    #url(r"^concert/(?P<concert_id>\d+)/annotations/(?P<pk>\d+)$", views.annotation_detail),
+    url(r"^concert/(?P<concert_id>\d+)/new_annotation/$", views.create_annotation), #url for creating new annotation for the concert
+    url(r"^annotation/(?P<pk>\d+)/$", views.get_annotation), #returns a specific annotation
+    url(r"^annotation/(?P<pk>\d+)/$", views.delete_annotation), #deletes the annotation with pk
+    url(r"^annotations/$", views.all_annotations),#returns all annotations
     # LOCATION
     url(r'^locations/$',views.list_locations), # lists all locations in DB
     url(r'^location/(?P<pk>[0-9]+)/$',views.location_detail), # gets a specific location in DB

--- a/lfc-api/LookingForConcerts/lfc_backend/models.py
+++ b/lfc-api/LookingForConcerts/lfc_backend/models.py
@@ -128,7 +128,7 @@ class ConcertReport(models.Model):
         ("IMAGE","image"),
     )
     report_type = models.CharField(choices=REPORT_TYPES, max_length=20, null=True)
-    concert = models.ForeignKey(Concert, related_name = 'reports',on_delete = models.CASCADE)
+    concert = models.ForeignKey(Concert, related_name = 'reports',on_delete = models.CASCADE, null=True)
     suggestion = models.CharField(max_length=1000)  # the suggestion as an alternative to the reported information.
 
 class Rating(models.Model):
@@ -169,20 +169,18 @@ class Annotation(models.Model):
 
     # id created automatically
     annotation_id = ("http://" + settings.HOST + ":" + settings.FRONTEND_PORT + "/annotations/{}").format(id)
-    concert = models.ForeignKey(Concert, related_name="annotations", on_delete=models.CASCADE, blank=True)
     context = models.URLField(null=False, default="http://www.w3.org/ns/anno.jsonld")
     type = models.CharField(max_length=255, null=False, default="Annotation")
     motivation = models.CharField(choices=MOTIVATIONS, max_length=20, null=True) # the reason for creating this annotation
-    creator = models.ForeignKey(RegisteredUser, related_name="annotations", on_delete=models.CASCADE, blank=True)
+    creator = models.ForeignKey(RegisteredUser, related_name="annotations", on_delete=models.CASCADE, null=True)
     created = models.DateTimeField(auto_now_add=True)
-    upvotes = models.IntegerField(null=False, default=0)
-
+    upvotes = models.IntegerField(null = True)
 class AnnotationBodyAndTargetCommon(models.Model):
     TYPES = (
-    ('TEXT', 'text'),
-    ('VIDEO', 'video'),
-    ('AUDIO', 'audio'),
-    ('IMAGE', 'image'),
+    ('TEXT', 'Text'),
+    ('VIDEO', 'Video'),
+    ('AUDIO', 'Audio'),
+    ('IMAGE', 'Image'),
     )
 
     MIMES = (
@@ -233,14 +231,14 @@ class AnnotationBody(AnnotationBodyAndTargetCommon):
         ('REPLYING', 'replying'),
         ('TAGGING', 'tagging'),
     )
-    annotation = models.ForeignKey(Annotation, related_name="body", on_delete=models.CASCADE)
+    annotation = models.ForeignKey(Annotation, related_name="body", on_delete=models.CASCADE, null=True)
     purpose = models.CharField(choices=PURPOSES, max_length=20, null=True)
     value = models.CharField(max_length=255, null=False)
 
 # the target for our Annotation class
 class AnnotationTarget(AnnotationBodyAndTargetCommon):
-    annotation = models.ForeignKey(Annotation, related_name="target", on_delete=models.CASCADE)
-    target_id = models.CharField(max_length=255, null=False, default=("http://" + settings.HOST + ":" + settings.FRONTEND_PORT + "/concert/null/"))
+    annotation = models.ForeignKey(Annotation, related_name="target", on_delete=models.CASCADE, null=True)
+    target_id = models.CharField(max_length=255, null=False, default=("http://" + settings.HOST + ":" + settings.FRONTEND_PORT + "/concert/null"))
 
 # W3C Specification for selectors
 # 4.2 Selectors


### PR DESCRIPTION
…d Views

#317

Serializers and views related to Annotation have been implemented.

Endpoints:
- GET: concerts_annotations/?url=\<concertUrl\> 
returns all annotations about a concert. It returns the annotations that contains a target which have concertURL as their target_id.

- POST: concert/\<concertId\>/new_annotation/ 
creates a new annotation for a concert.

- GET: annotation/\<annotationId\>/ 
returns the annotation that have the annotationId as the value of its id field. (!!not annotation_id!!)

- DELETE: annotation/\<annotationId\>/ 
deletes the annotation with annotationId pk value. 

- GET: annotations/ 
returns all annotations